### PR TITLE
Use of tokens

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "prefer-stable": true,
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "guzzlehttp/guzzle": ">=6.0",
         "aws/aws-sdk-php": ">=3.0"
     },

--- a/config/config.php
+++ b/config/config.php
@@ -145,4 +145,16 @@ return [
     |
     */
     'force_password_auto_update_api' => env('AWS_COGNITO_FORCE_PASSWORD_AUTO_UPDATE_API', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session keys for Cognito tokens
+    |--------------------------------------------------------------------------
+    |
+    | These keys are used to store the different Cognito tokens into the session object.
+    |
+     */
+    'session_access_token_key'  => env('AWS_COGNITO_SESSION_ACCESS_TOKEN_KEY', 'cognito.AccessToken'),
+    'session_refresh_token_key' => env('AWS_COGNITO_SESSION_REFRESH_TOKEN_KEY', 'cognito.RefreshToken'),
+    'session_id_token_key'      => env('AWS_COGNITO_SESSION_ID_TOKEN_KEY', 'cognito.IdToken'),
 ];

--- a/src/AwsCognitoClient.php
+++ b/src/AwsCognitoClient.php
@@ -688,7 +688,6 @@ class AwsCognitoClient
 
         try {
             $response = $this->client->AdminInitiateAuth($payload);
-
         } catch (CognitoIdentityProviderException $e) {
         }
 
@@ -753,6 +752,7 @@ class AwsCognitoClient
     public function getUserByToken(string $accesstoken)
     {
         $user = null;
+
         try {
             $user = $this->client->GetUser([
                 'AccessToken' => $accesstoken,

--- a/src/AwsCognitoClient.php
+++ b/src/AwsCognitoClient.php
@@ -649,6 +649,53 @@ class AwsCognitoClient
         return $successful;
     }
 
+    /**
+     * @param string      $refreshToken
+     * @param string|null $secretHash
+     * @param string|null $deviceKey
+     * @param array|null  $clientMetadata
+     *
+     * @return \Aws\Result|null
+     */
+    public function adminInitiateAuthByToken(
+        string $refreshToken,
+        ?string $secretHash = null,
+        ?string $deviceKey = null,
+        ?array $clientMetadata = null
+    ) : ?\Aws\Result {
+        $response = null;
+
+        $payload = [
+            'AuthFlow'       => 'REFRESH_TOKEN_AUTH',
+            'AuthParameters' => [
+                'REFRESH_TOKEN' => $refreshToken,
+            ],
+            'ClientId'       => $this->clientId,
+            'UserPoolId'     => $this->poolId,
+        ];
+
+        if (null !== $secretHash) {
+            $payload['AuthParameters']['SECRET_HASH'] = $secretHash;
+        }
+
+        if (null !== $deviceKey) {
+            $payload['AuthParameters']['DEVICE_KEY'] = $deviceKey;
+        }
+
+        if (null !== $clientMetadata) {
+            $payload['ClientMetadata'] = $clientMetadata;
+        }
+
+        try {
+            $response = $this->client->AdminInitiateAuth($payload);
+
+        } catch (CognitoIdentityProviderException $e) {
+        }
+
+        return $response;
+    }
+
+
     public function adminConfirmSignUp(string $username, array $clientMetadata = []) : bool
     {
         $successful = false;
@@ -701,6 +748,19 @@ class AwsCognitoClient
         }
 
         return $successful;
+    }
+
+    public function getUserByToken(string $accesstoken)
+    {
+        $user = null;
+        try {
+            $user = $this->client->GetUser([
+                'AccessToken' => $accesstoken,
+            ]);
+        } catch (CognitoIdentityProviderException $e) {
+        }
+
+        return $user;
     }
 
     /**

--- a/src/Guards/CognitoSessionGuard.php
+++ b/src/Guards/CognitoSessionGuard.php
@@ -199,7 +199,7 @@ class CognitoSessionGuard extends SessionGuard implements StatefulGuard
         try {
             $result = $this->client->adminInitiateAuthByToken($refreshToken, $secretHash, $deviceKey, $clientMetadata);
             $result['AuthenticationResult']['RefreshToken'] = $refreshToken;
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             return null;
         }
 

--- a/src/Guards/CognitoSessionGuard.php
+++ b/src/Guards/CognitoSessionGuard.php
@@ -83,7 +83,9 @@ class CognitoSessionGuard extends SessionGuard implements StatefulGuard
                 $this->challengeName = $result['ChallengeName'];
             }
 
-            return $user instanceof Authenticatable;
+            $this->parseAuthenticationResult($result);
+
+            return $result['@metadata']['statusCode'] === 200 && isset($result['AuthenticationResult']['AccessToken']);
         }
 
         return false;
@@ -183,6 +185,47 @@ class CognitoSessionGuard extends SessionGuard implements StatefulGuard
             $this->fireFailedEvent($user, $credentials);
 
             return false;
+        }
+    }
+
+    public function refreshToken(
+        ?string $refreshToken = null,
+        ?string $secretHash = null,
+        ?string $deviceKey = null,
+        ?array $clientMetadata = null
+    ) : ?string {
+        $refreshToken = $refreshToken ?? session(config('AWS_COGNITO_SESSION_REFRESH_TOKEN_KEY'));
+
+        try {
+            $result = $this->client->adminInitiateAuthByToken($refreshToken, $secretHash, $deviceKey, $clientMetadata);
+            $result['AuthenticationResult']['RefreshToken'] = $refreshToken;
+        } catch(Exception $e) {
+            return null;
+        }
+
+        $this->parseAuthenticationResult($result);
+
+        return $result['AuthenticationResult']['RefreshToken'] ?? null;
+    }
+
+    /**
+     * @param string|null $accessToken
+     *
+     * @return AwsResult|null AWS User object
+     */
+    public function getUserByToken(?string $accessToken = null)
+    {
+        $accessToken = $accessToken ?? session()->get(config('cognito.session_access_token_key'));
+
+        return $this->client->getUserByToken($accessToken);
+    }
+
+    protected function parseAuthenticationResult(\Aws\Result $result)
+    {
+        if (isset($result['AuthenticationResult']['AccessToken'])) {
+            $this->getSession()->put(config('cognito.session_access_token_key'), $result['AuthenticationResult']['AccessToken']);
+            $this->getSession()->put(config('cognito.session_refresh_token_key'), $result['AuthenticationResult']['RefreshToken']);
+            $this->getSession()->put(config('cognito.session_id_token_key'), $result['AuthenticationResult']['IdToken']);
         }
     }
 }


### PR DESCRIPTION
## Description

Updated to store tokens within session
Session key is part of config file
Added ability to get user via AccessToken
Added ability to refresh token via session guard
Added ability to authenticate via token
Updated composer to allow PHP 8.0 or 7.4

## Release Notes

Updated to store tokens within session
Session key is part of config file
Added ability to get user via AccessToken
Added ability to refresh token via session guard
Added ability to authenticate via token
Updated composer to allow PHP 8.0 or 7.4

## Types of changes

- [ ] Bugfix
- [X] Enhancement
- [ ] Maintenance (clean up)

## Checklist

- [ ] Unit tests pass locally
- [X] Manually tested changes
- [ ] Added tests to code that was updated or edited
- [ ] Updated documentation

## Steps to test or review

_TODO: List of steps to test changes_
